### PR TITLE
Add first Jest test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,4 +16,4 @@ const customJestConfig = {
   ],
 };
 
-module.exports = createJestConfig(customJestConfig);
+export default createJestConfig(customJestConfig);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,15 @@
+import { cn } from '@/lib/utils';
+
+describe('cn utility', () => {
+  it('joins class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('ignores falsy values', () => {
+    expect(cn('foo', false && 'bar', undefined, null, '')).toBe('foo');
+  });
+
+  it('merges tailwind classes', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4');
+  });
+});


### PR DESCRIPTION
## Summary
- enable ESM export in jest.config.js
- add tests directory and a simple test for the `cn` utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68461d248d3c8321a147d1191293bc01